### PR TITLE
Update openvoice_wrapper docs

### DIFF
--- a/openvoice_wrapper.py
+++ b/openvoice_wrapper.py
@@ -1,14 +1,57 @@
+"""Utility wrapper for integrating OpenVoice TTS models.
+
+This module currently contains only a stub implementation. The
+``synthesize_openvoice`` function below simply writes a silent audio file and
+does **not** run any real OpenVoice inference.
+
+To enable actual OpenVoice synthesis you will need to download the official
+models and place them under ``models/OpenVoice``. Once the models are present
+you can replace the stub code with calls to the real inference pipeline (for
+example using ``fairseq`` or the OpenVoice API).
+"""
+
+import os
 import torch
 import torchaudio
-import os
 
+# Directory where the OpenVoice checkpoints should live. The application
+# expects ``models/OpenVoice`` relative to this repository. Adjust this path if
+# your setup differs.
 OPENVOICE_MODEL_PATH = "models/OpenVoice"
 
-def synthesize_openvoice(text, speaker_wav_path, output_wav_path):
+
+def synthesize_openvoice(text: str, speaker_wav_path: str, output_wav_path: str) -> str:
+    """Generate speech with OpenVoice (stub).
+
+    Parameters
+    ----------
+    text: str
+        Text to synthesize.
+    speaker_wav_path: str
+        Path to a reference speaker WAV file.
+    output_wav_path: str
+        Destination path for the generated audio.
+
+    Returns
+    -------
+    str
+        Path to the resulting WAV file.
+
+    Notes
+    -----
+    This stub simply writes three seconds of silence to demonstrate how the
+    function is expected to behave. Replace this implementation with actual
+    model loading and inference once the OpenVoice checkpoints are available in
+    ``OPENVOICE_MODEL_PATH``.
+    """
+
     print(f"[OpenVoice] Synthesizing: '{text}' with speaker: {speaker_wav_path}")
+
+    # Placeholder behaviour: create a silent audio file.
     sample_rate = 22050
     duration_seconds = 3
     silence = torch.zeros(int(sample_rate * duration_seconds))
     torchaudio.save(output_wav_path, silence.unsqueeze(0), sample_rate)
+
     print(f"[OpenVoice] Output saved: {output_wav_path}")
     return output_wav_path


### PR DESCRIPTION
## Summary
- document that OpenVoice wrapper is a stub
- describe how to integrate real OpenVoice checkpoints

## Testing
- `python -m py_compile openvoice_wrapper.py`


------
https://chatgpt.com/codex/tasks/task_e_6843baf600e8832f9332efcb6cc904b4