### PR TITLE
Improve device fallback

### DIFF
--- a/app_v3.py
+++ b/app_v3.py
@@ -33,7 +33,9 @@ if not os.path.exists(PROFILES_FILE):
 
 # Current TTS model instance
 tts = TTS(model_name=DEFAULT_MODEL, progress_bar=False)
-tts.to("cuda")
+# Use GPU if available, otherwise fall back to CPU
+device = "cuda" if torch.cuda.is_available() else "cpu"
+tts.to(device)
 current_model = DEFAULT_MODEL
 
 def load_tts_model(model_name):
@@ -42,7 +44,9 @@ def load_tts_model(model_name):
     if model_name == current_model:
         return gr.update()
     tts = TTS(model_name=model_name, progress_bar=False)
-    tts.to("cuda")
+    # Move to GPU if available, otherwise stay on CPU
+    device = "cuda" if torch.cuda.is_available() else "cpu"
+    tts.to(device)
     current_model = model_name
     speakers = (
         tts.speakers if tts.is_multi_speaker else ["default"]

--- a/setup_instructions.txt
+++ b/setup_instructions.txt
@@ -24,3 +24,4 @@ They will appear as "Clone: Name" in speaker dropdown.
   menu when launching the app.
 - OpenVoice integration is ready via openvoice_wrapper.py. You can expand it to
   run full OpenVoice inference.
+- If CUDA is not available, the app automatically falls back to CPU execution.


### PR DESCRIPTION
## Summary
- handle GPU/CPU detection when loading TTS models
- mention CUDA fallback in setup docs

## Testing
- `python -m py_compile app_v3.py openvoice_wrapper.py`


------
https://chatgpt.com/codex/tasks/task_e_6843bafdf458832f8140d9d73773e87d