### PR TITLE
Add speaker wav existence check

### DIFF
--- a/app_v3.py
+++ b/app_v3.py
@@ -70,6 +70,14 @@ def synthesize(text, model_label, speaker_id, emotion, pitch, speed):
     load_tts_model(model_name)
     if speaker_id in openvoice_speakers:
         speaker_wav = openvoice_speakers[speaker_id]
+        if not os.path.isfile(speaker_wav):
+            msg = f"Speaker WAV file not found: {speaker_wav}"
+            try:
+                gr.Warning(msg)
+            finally:
+                print(msg)
+            return None
+
         with tempfile.NamedTemporaryFile(suffix=".wav", delete=False) as tmpfile:
             tmpfile_path = tmpfile.name
         synthesize_openvoice(text, speaker_wav, tmpfile_path)


### PR DESCRIPTION
## Summary
- validate that the selected OpenVoice speaker WAV exists before synthesis
- warn the user when the file is missing

## Testing
- `python -m py_compile app_v3.py openvoice_wrapper.py`

------
https://chatgpt.com/codex/tasks/task_e_6843bb082c08832f8031e410e0519a05